### PR TITLE
Only package up the important files

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
   "devDependencies": {
     "cheerio": "^0.17.0",
     "superagent": "^0.18.2"
-  }
+  },
+  "files": [
+    "index.js",
+    "LICENSE"
+  ]
 }


### PR DESCRIPTION
Avoids sending .gitattributes, .travis.yml, etc. down the wire.
